### PR TITLE
Add balance increment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 venv
 *.pyc
 
+output.log
+dbdata
+.idea
+.pytest_cache

--- a/database.py
+++ b/database.py
@@ -180,7 +180,7 @@ class IndexerState(Base):
     last_time = Column(TIMESTAMP, nullable=False, default=datetime(1970, 1, 1, 1))
     balance_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0)
     apy = Column(Float, nullable=False, default=0.0)
-    apy_50ms_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0)
+    apy_50ms_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0) # TODO: Remove unused column
 
 def main():
     Base.metadata.create_all(engine)

--- a/indexer.py
+++ b/indexer.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from web3.constants import ADDRESS_ZERO
 
 from sqlalchemy.exc import IntegrityError
+from utils import time_delta_apy
 
 YEAR = Decimal(timedelta(days=365).total_seconds())
 getcontext().prec = 78
@@ -41,13 +42,12 @@ class Indexer:
         usdc, factor = position.get_balance_data(block)
 
         # TODO make compounding?
-        apy = YEAR / Decimal(position_timedelta) * (factor - 1)
+        apy = time_delta_apy(position.usdc, usdc, position_timedelta)
 
         indx.balance_factor = factor
         # If no payout has occured since the last loop
         if apy > 0.0:
-            indx.apy = round(apy * 100, 2)
-            indx.apy_50ms_factor = apy / YEAR / 60 / 60 / 60 / 20
+            indx.apy = apy
 
         indx.block_last_updated = block
         indx.last_time = datetime.fromtimestamp(timestamp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,5 @@ websockets==9.1
 Werkzeug==2.0.2
 yarl==1.7.2
 zipp==3.6.0
+
+pytest==7.1.0  # https://docs.pytest.org/en/stable/

--- a/tests/test_apy.py
+++ b/tests/test_apy.py
@@ -1,0 +1,37 @@
+import math
+from decimal import Decimal
+
+import pytest
+
+from utils import time_delta_apy, SECONDS_IN_A_YEAR, calculate_increment
+
+
+@pytest.mark.parametrize("old, new, time_delta, apy",
+                         [(1, 1.01, 1, SECONDS_IN_A_YEAR / 100),
+                          (1, 1.02, 1, 2 * SECONDS_IN_A_YEAR / 100),
+                          (1, 1.01, 2, SECONDS_IN_A_YEAR / 100 / 2),
+                          (1, 1.25, SECONDS_IN_A_YEAR / 4, 1)])
+def test_apy_computed_correctly(old, new, time_delta, apy):
+    computed_apy = time_delta_apy(old, new, time_delta)
+
+    # Check equality with a 1e-6 (6 decimals) precision
+    assert math.isclose(apy, computed_apy, rel_tol=1e-6)
+
+
+@pytest.mark.parametrize("apy, amount, time_delta",
+                         [(Decimal(2), Decimal(1), SECONDS_IN_A_YEAR ),
+                          (Decimal(39), Decimal(324.98), 120),
+                          (Decimal(0.04), Decimal(1000), 1)])
+def test_increment_computed_correctly(apy, amount, time_delta):
+    # Compute the increment from the APY and the amount
+    increment = calculate_increment(amount, apy)
+
+    # Compute the amount after `time_delta` seconds
+    new_amount = amount + (increment * time_delta)
+
+    # Compute APY from the change
+    resulting_apy = time_delta_apy(amount, new_amount, time_delta)
+
+    # Resulting APY should be the same as the one used for calculating the APY
+    # Check equality with a 1e-6 (6 decimals) precision
+    assert math.isclose(resulting_apy, apy, rel_tol=1e-6)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,35 @@
+from datetime import timedelta
+from decimal import Decimal
+
+SECONDS_IN_A_YEAR = Decimal(timedelta(days=365).total_seconds())
+
+
+def time_delta_apy(old, new, time_delta):
+    """
+    Compute APY based on the delta of two position balances.
+    :param old: Old value (e.g. old position balance)
+    :param new: New value
+    :param time_delta Seconds passed between `old` and `new`
+    :return: Annual Percentage Yield (1.3 => 130%)
+    """
+    factor = Decimal(new) / Decimal(old)
+    growth = factor - 1
+
+    growth_per_second = growth / Decimal(time_delta)
+    apy = growth_per_second * SECONDS_IN_A_YEAR
+
+    return apy
+
+
+def calculate_increment(amount, apy):
+    """
+    Compute an amount that can be added, every second,
+    to any balance affected by APY, in order generate
+    a real-time balance.
+    :param amount: The starting amount
+    :param apy: Annual Percentage Yield (1.30 => 130%)
+    :return: Increment value
+    """
+    one_year_yield = Decimal(amount) * Decimal(apy)
+
+    return one_year_yield / SECONDS_IN_A_YEAR


### PR DESCRIPTION
- Isolated APY & 1s balance incrementing computation
- Wrote few tests for APY and balance increments computation
- Used everywhere the numeric value of the APY, and only multiply by 100 to get the percentage value in the `app.py` response (although we should migrate to returning the numeric value and let the frontend take care of it)
- Stopped using and updating the `apy_50ms_factor` value (marked it as unused)