### PR TITLE
Upgrade script

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -14,7 +14,8 @@ config.set_main_option("sqlalchemy.url", settings.DATABASE_URI)
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    if config.attributes.get("configure_logger", True):
+        fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/database.py
+++ b/database.py
@@ -3,6 +3,16 @@ import sys
 from models import IndexerState, Session, StakingPositionsMeta
 
 
+def run(start_block):
+    s = Session()
+    s.add(StakingPositionsMeta())
+    i = IndexerState()
+    i.last_block = start_block
+    s.add(i)
+    s.commit()
+    s.close()
+
+
 def main():
     if len(sys.argv) != 2:
         sys.exit("Usage: python database.py <start-block>")
@@ -11,13 +21,7 @@ def main():
     except ValueError:
         sys.exit("Usage: python database.py <start-block>")
 
-    s = Session()
-    s.add(StakingPositionsMeta())
-    i = IndexerState()
-    i.last_block = start_block
-    s.add(i)
-    s.commit()
-    s.close()
+    run(start_block)
 
 
 if __name__ == "__main__":

--- a/indexer.py
+++ b/indexer.py
@@ -26,7 +26,12 @@ logging.basicConfig(filename="output.log", level=logging.INFO)
 
 
 class Indexer:
-    def __init__(self):
+    blocks_per_call = settings.INDEXER_BLOCKS_PER_CALL
+
+    def __init__(self, blocks_per_call=None):
+        if blocks_per_call:
+            self.blocks_per_call = blocks_per_call
+
         self.events = {
             settings.CORE_WSS.events.Transfer: self.Transfer.new,
             settings.CORE_WSS.events.Restaked: self.Restaked.new,
@@ -178,7 +183,7 @@ class Indexer:
                 s = Session()
 
                 # Process 5 blocks each round
-                end_block = start_block + settings.INDEXER_BLOCKS_PER_CALL - 1
+                end_block = start_block + self.blocks_per_call - 1
                 current_block = settings.WEB3_WSS.eth.blockNumber
 
                 if end_block >= current_block:
@@ -207,7 +212,7 @@ class Indexer:
 
     def index_intervals(self, session, indx, block):
         for func, interval in self.intervals.items():
-            if block % interval >= settings.INDEXER_BLOCKS_PER_CALL:
+            if block % interval >= self.blocks_per_call:
                 continue
 
             try:

--- a/indexer.py
+++ b/indexer.py
@@ -18,7 +18,7 @@ from models import (
     StakingPositionsMeta,
     StatsTVL,
 )
-from utils import time_delta_apy
+from utils import get_event_logs_in_range, time_delta_apy
 
 YEAR = Decimal(timedelta(days=365).total_seconds())
 getcontext().prec = 78
@@ -246,8 +246,8 @@ class Indexer:
     def index_events(self, session, indx, start_block, end_block):
         # Commit on every insert so indexer doesn't halt on single failure
         for event, func in self.events.items():
-            filter = event.createFilter(fromBlock=start_block, toBlock=end_block)
-            for entry in filter.get_all_entries():
+            entries = get_event_logs_in_range(event, start_block, end_block)
+            for entry in entries:
                 try:
                     func(self, session, indx, entry["blockNumber"], entry["args"])
                     session.commit()

--- a/indexer.py
+++ b/indexer.py
@@ -44,6 +44,9 @@ class Indexer:
     def calc_factors(self, session, indx, block):
         meta = StakingPositionsMeta.get(session)
 
+        if meta.usdc_last_updated == datetime.min:
+            return
+
         timestamp = settings.WEB3_WSS.eth.get_block(block)["timestamp"]
         position_timedelta = timestamp - meta.usdc_last_updated.timestamp()
         if position_timedelta == 0:

--- a/indexer.py
+++ b/indexer.py
@@ -16,7 +16,7 @@ from models import (
     Session,
     StakingPositions,
     StakingPositionsMeta,
-    StatsTVL
+    StatsTVL,
 )
 from utils import time_delta_apy
 
@@ -38,10 +38,7 @@ class Indexer:
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolRemoved: self.ProtocolRemoved.new,
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolRemovedByArb: self.ProtocolRemoved.new,
         }
-        self.intervals = {
-            self.calc_tvl: settings.INDEXER_STATS_BLOCKS_PER_CALL,
-            self.calc_factors: 1
-        }
+        self.intervals = {self.calc_tvl: settings.INDEXER_STATS_BLOCKS_PER_CALL, self.calc_factors: 1}
 
     # Also get called after listening to events with `end_block`
     def calc_factors(self, session, indx, block):
@@ -193,7 +190,8 @@ class Indexer:
 
                 # self.index_events_time needs to be executed first.
                 # The Transfer updates meta.usdc_last_updated on line with StakingPositionsMeta.update.
-                # This variable is again uses in calc_factors with position_timedelta = timestamp - meta.usdc_last_updated.timestamp()
+                # This variable is again uses in calc_factors with
+                # position_timedelta = timestamp - meta.usdc_last_updated.timestamp()
                 self.index_events_time(s, indx, start_block, end_block)
                 self.index_intervals(s, indx, end_block)
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -214,7 +214,7 @@ def start_new_indexer(screen_name: str):
     run_shell_command(command)
 
     # Let process start
-    sleep(2)
+    sleep(5)
 
     pid = find_indexer_pid()
     if not pid:

--- a/upgrade.py
+++ b/upgrade.py
@@ -34,10 +34,11 @@ def parse_args():
     return parser.parse_args()
 
 
-def create_new_database(connection: Connection) -> str:
+def create_new_database(prefix: str, connection: Connection) -> str:
     """Creates a new database
 
     Args:
+        prefix (str): DB name prefix
         connection (Connection): Live DB connection
 
     Returns:
@@ -46,7 +47,7 @@ def create_new_database(connection: Connection) -> str:
     logging.info("[+] Creating new database...")
 
     # Generate the name by apppending current timestamp
-    new_db_name = "indexer_" + str(int(datetime.now().timestamp()))
+    new_db_name = f"{prefix}_{str(int(datetime.now().timestamp()))}"
 
     # End open transaction using COMMIT (cannot create databases inside transactions)
     connection.execute("commit")
@@ -243,7 +244,7 @@ def main():
     connection = settings.DB.connect()
 
     # Create the new database
-    db_name = create_new_database(connection)
+    db_name = create_new_database(args.service, connection)
 
     # Update .env
     update_env(db_name)

--- a/upgrade.py
+++ b/upgrade.py
@@ -4,6 +4,8 @@ import os
 import re
 from argparse import ArgumentParser
 from datetime import datetime
+from threading import Thread
+from time import sleep
 
 import settings
 from alembic import command
@@ -16,7 +18,12 @@ def parse_args():
     """Parse CLI arguments"""
     parser = ArgumentParser()
     parser.add_argument(
-        "-b", "--block", dest="block", help="Block number to start reindexing from", type=int, required=True
+        "-b",
+        "--block",
+        dest="block",
+        help="Block number to start reindexing from",
+        type=int,
+        required=True,
     )
 
     return parser.parse_args()
@@ -77,12 +84,16 @@ def run_db_migrations():
     # Force reimporting settings module to use the new env variables
     importlib.reload(settings)
 
-    config = Config("./alembic.ini")
+    config = Config("alembic.ini")
+    config.attributes["configure_logger"] = False
+
     command.upgrade(config, "head")
 
 
 def initialize_database(block_number):
     """Initialize the new database"""
+    logging.info(f"[+] Initializing the DB to block {block_number}...")
+
     import database
 
     database.run(block_number)
@@ -91,9 +102,109 @@ def initialize_database(block_number):
 def reindex():
     """Index events until up to date"""
     from indexer import Indexer
+    from models import IndexerState, Session
+
+    current_block_number = settings.WEB3_WSS.eth.blockNumber
+    logging.info(f"[+] Indexing until block {current_block_number}")
 
     indexer = Indexer()
-    indexer.start()
+    thread = Thread(name="Indexer", target=indexer.start)
+    thread.start()
+
+    # Wait for the DB to get up to date
+    with Session() as s:
+        while True:
+            s.expire_all()
+            state = s.query(IndexerState).first()
+            logging.info(f"[+] - Last indexed block: {state.last_block}")
+
+            if state.last_block >= current_block_number:
+                break
+
+            sleep(2)
+
+    thread.do_run = False
+    thread.join()
+
+
+def run_shell_command(command: str) -> str:
+    """Run a shell command an capture it's output.
+
+    Args:
+        command (str): Command to execute
+
+    Returns:
+        str: Command output
+    """
+    logging.debug("[ ] Executing command: " + command)
+    with os.popen(command) as stream:
+        output = stream.read()
+        logging.debug(f"[ ] Output: \r\n{output}")
+
+        return output
+
+
+def find_indexer_pid() -> str:
+    """Search indexer's process ID.
+
+    Search is being done by looking for a process started with `python` command, by user `evert`
+    in the current working directory.
+
+    We filter resulting entries using `ps` to extract only the `python` process that
+    started the `indexer.py` script.
+
+
+    Returns:
+        str: Indexer's process PID
+    """
+    command = "lsof -u acelasi -c python -d cwd -a -t -f -- ."
+    output = run_shell_command(command)
+    pids = re.findall(r"\d+", output)
+
+    command = f'ps x | grep -E "{"|".join(pids)}" | grep "python [i]ndexer.py" | awk \'{{ print $1 }}\''
+    output = run_shell_command(command)
+
+    try:
+        return re.match(r"\d+", output).group(0)
+    except Exception:
+        return None
+
+
+def stop_indexer_process(pid: str):
+    """Kills the indexer process, gracefuly.
+
+    Args:
+        pid (str): Process PID
+    """
+    logging.info(f"[+] Stopping process {pid}...")
+
+    command = f"kill -s TERM {pid}"
+    run_shell_command(command)
+
+    # Wait for the process to exit
+    while find_indexer_pid() is not None:
+        sleep(2)
+
+
+def start_new_indexer():
+    """Start a new indexer."""
+    logging.info("[+] Starting new indexer process...")
+
+    command = "screen -d -m python indexer.py"
+    run_shell_command(command)
+
+    # Let process start
+    sleep(2)
+
+    pid = find_indexer_pid()
+    if not pid:
+        raise Exception("Failed starting a new indexer process!")
+
+    logging.info(f"[+] New indexer process started {pid}")
+
+
+def restart_service():
+    logging.info("[+] Restarting API service...")
 
 
 def main():
@@ -114,7 +225,20 @@ def main():
     # Run indexer on new database until up to date
     reindex()
 
-    # TODO: Trigger main app restart/reload
+    # Fetch indexer PID
+    pid = find_indexer_pid()
+
+    if not pid:
+        raise Exception("Could not find indexer PID.")
+
+    # Kill indexer
+    stop_indexer_process(pid)
+
+    # Spawn another indexer
+    start_new_indexer()
+
+    # Restart API service
+    restart_service()
 
 
 if __name__ == "__main__":

--- a/upgrade.py
+++ b/upgrade.py
@@ -25,6 +25,9 @@ def parse_args():
         type=int,
         required=True,
     )
+    parser.add_argument(
+        "-s", "--service", dest="service", help="The name of the service running the API", required=True
+    )
 
     return parser.parse_args()
 
@@ -203,8 +206,17 @@ def start_new_indexer():
     logging.info(f"[+] New indexer process started {pid}")
 
 
-def restart_service():
-    logging.info("[+] Restarting API service...")
+def restart_service(service: str):
+    """Restart API service.
+
+    Args:
+        service (str): Name of service running the API
+    """
+
+    logging.info(f"[+] Restarting API service {service}...")
+
+    command = f"sudo systemctl restart {service}"
+    run_shell_command(command)
 
 
 def main():
@@ -238,7 +250,7 @@ def main():
     start_new_indexer()
 
     # Restart API service
-    restart_service()
+    restart_service(args.service)
 
 
 if __name__ == "__main__":

--- a/upgrade.py
+++ b/upgrade.py
@@ -199,11 +199,18 @@ def stop_indexer_process(pid: str):
         sleep(2)
 
 
-def start_new_indexer():
-    """Start a new indexer."""
+def start_new_indexer(screen_name: str):
+    """Start a new indexer.
+
+    Args:
+        screen_name (str): Newly created screen session name
+
+    Raises:
+        Exception: Error when starting a new indexer process
+    """
     logging.info("[+] Starting new indexer process...")
 
-    command = "screen -d -m python indexer.py"
+    command = f"screen -S {screen_name} -d -m python indexer.py"
     run_shell_command(command)
 
     # Let process start
@@ -260,7 +267,7 @@ def main():
     stop_indexer_process(pid)
 
     # Spawn another indexer
-    start_new_indexer()
+    start_new_indexer(args.service)
 
     # Close old DB connection
     connection.close()

--- a/upgrade.py
+++ b/upgrade.py
@@ -1,0 +1,121 @@
+import importlib
+import logging
+import os
+import re
+from argparse import ArgumentParser
+from datetime import datetime
+
+import settings
+from alembic import command
+from alembic.config import Config
+
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_args():
+    """Parse CLI arguments"""
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-b", "--block", dest="block", help="Block number to start reindexing from", type=int, required=True
+    )
+
+    return parser.parse_args()
+
+
+def create_new_database() -> str:
+    """Creates a new database
+
+    Returns:
+        str: The name of the newly created database
+    """
+    logging.info("[+] Creating new database...")
+
+    # Generate the name by apppending current timestamp
+    new_db_name = "indexer_" + str(int(datetime.now().timestamp()))
+
+    # Create db connection
+    conn = settings.DB.connect()
+
+    # End open transaction using COMMIT (cannot create databases inside transactions)
+    conn.execute("commit")
+
+    # Create the database
+    conn.execute("create database " + new_db_name)
+    conn.close()
+
+    logging.info("[ ] Created database " + new_db_name)
+
+    # Update env variable for the rest of this script's execution
+    os.environ["DB_NAME"] = new_db_name
+
+    return new_db_name
+
+
+def update_env(db_name: str):
+    """Update DB_NAME in .env file
+
+    Args:
+        db_name (str): New database name
+    """
+    logging.info("[+] Updating .env...")
+
+    with open("./.env") as f:
+        current_env = f.read()
+
+    # Update DB_NAME field
+    new_env = re.sub(r"DB_NAME=(.*)", "DB_NAME=" + db_name, current_env)
+
+    with open("./.env", "w") as f:
+        f.write(new_env)
+
+
+def run_db_migrations():
+    """Get DB structure up to date by running
+    available database migration scripts."""
+    logging.info("[+] Running DB migrations...")
+
+    # Force reimporting settings module to use the new env variables
+    importlib.reload(settings)
+
+    config = Config("./alembic.ini")
+    command.upgrade(config, "head")
+
+
+def initialize_database(block_number):
+    """Initialize the new database"""
+    import database
+
+    database.run(block_number)
+
+
+def reindex():
+    """Index events until up to date"""
+    from indexer import Indexer
+
+    indexer = Indexer()
+    indexer.start()
+
+
+def main():
+    args = parse_args()
+
+    # Create the new database
+    db_name = create_new_database()
+
+    # Update .env
+    update_env(db_name)
+
+    # Run migrations
+    run_db_migrations()
+
+    # Initialize database
+    initialize_database(args.block)
+
+    # Run indexer on new database until up to date
+    reindex()
+
+    # TODO: Trigger main app restart/reload
+
+
+if __name__ == "__main__":
+    main()

--- a/upgrade.py
+++ b/upgrade.py
@@ -170,7 +170,7 @@ def find_indexer_pid() -> str:
     Returns:
         str: Indexer's process PID
     """
-    command = "lsof -u acelasi -c python -d cwd -a -t -f -- ."
+    command = "lsof -u evert -c python -d cwd -a -t -f -- ."
     output = run_shell_command(command)
     pids = re.findall(r"\d+", output)
 


### PR DESCRIPTION
Created an upgrade script that allows for reindexing events without downtime.

## How it works?
1. Creates a new database with the following format: `[SERVICE_NAME]_[TIMESTAMP]` where `SERVICE_NAME` is passed as an argument and `TIMESTAMP` is the creation timestamp;
2. Updates `.env` file to point to the newly created database;
3. Runs alembic migrations against the newly created database;
4. Initialises the database with `database.py`;
5. Spawns an indexer in a separate thread, on the new database, and waits until it gets up to date with the live indexer, and then kills the thread;
6. Kills the live indexer process;
7. Spawns another indexer process inside a `screen` session named `[SERVICE_NAME]`
8. Restarts the `[SERVICE_NAME]` systemd service to use the new `.env.`

The live API is still serving requests from the old database until step **8** and the old database is being kept up to date, by the live indexer who is continuing to index events until step **6**. This ensures an upgrade without any API downtime.

## Usage

**Note: Should be run from the directory where each corresponding `.env` is located.** 

```
usage: upgrade.py [-h] -b BLOCK -s SERVICE

optional arguments:
  -h, --help            show this help message and exit
  -b BLOCK, --block BLOCK
                        Block number to start reindexing from
  -s SERVICE, --service SERVICE
                        The name of the service running the API
```

For example, with the current setup, to upgrade the Goerli indexer and reindex starting from block number `6451865` we would run:
```bash
$ python upgrade.py -b 6451865 -s indexer
```
and for the Mainnet indexer:
```bash
$ python upgrade.py -b 6451865 -s indexer_mainnet
```
