### PR TITLE
Fix balance factor update

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -126,12 +126,9 @@ class Indexer:
             logging.exception("TVC calc encountered exception %s" % e)
 
     def reset_apy_calc(self, session, indx, block):
-        # SKip computing the APY if there are no staking positions available
-        if not StakingPositions.get_for_factor(session):
-            return
-
-        # Do this call to get current `indx.balance_factor` value
-        self.calc_factors(session, indx, block)
+        # Compute the APY only if there is a staking position available
+        if StakingPositions.get_for_factor(session):
+            self.calc_factors(session, indx, block)
 
         # Update all staking positions with current factor
         StakingPositionsMeta.update(session, block, indx.balance_factor)

--- a/indexer.py
+++ b/indexer.py
@@ -130,11 +130,12 @@ class Indexer:
         # Do this call to get current `indx.balance_factor` value
         self.calc_factors(session, indx, block)
 
-        # Update all staking positions with current factor
-        StakingPositionsMeta.update(session, block, indx.balance_factor)
+        if indx.balance_factor != Decimal(1):
+            # Update all staking positions with current factor
+            StakingPositionsMeta.update(session, block, indx.balance_factor)
 
-        # Reset factor
-        indx.balance_factor = Decimal(1)
+            # Reset factor
+            indx.balance_factor = Decimal(1)
 
     class Transfer:
         def new(self, session, indx, block, args):

--- a/indexer.py
+++ b/indexer.py
@@ -134,11 +134,10 @@ class Indexer:
         self.calc_factors(session, indx, block)
 
         # Update all staking positions with current factor
-        if indx.balance_factor != Decimal(1):
-            StakingPositionsMeta.update(session, block, indx.balance_factor)
+        StakingPositionsMeta.update(session, block, indx.balance_factor)
 
-            # Reset factor
-            indx.balance_factor = Decimal(1)
+        # Reset factor
+        indx.balance_factor = Decimal(1)
 
     class Transfer:
         def new(self, session, indx, block, args):

--- a/indexer.py
+++ b/indexer.py
@@ -51,7 +51,6 @@ class Indexer:
         self.intervals = {
             self.calc_tvl: settings.INDEXER_STATS_BLOCKS_PER_CALL,
             self.calc_tvc: settings.INDEXER_STATS_BLOCKS_PER_CALL,
-            self.calc_factors: 1,
             # 268 blocks is roughly every hour on current Ethereum mainnet
             self.reset_apy_calc: 268
         }

--- a/indexer.py
+++ b/indexer.py
@@ -130,12 +130,11 @@ class Indexer:
         # Do this call to get current `indx.balance_factor` value
         self.calc_factors(session, indx, block)
 
-        if indx.balance_factor != Decimal(1):
-            # Update all staking positions with current factor
-            StakingPositionsMeta.update(session, block, indx.balance_factor)
+        # Update all staking positions with current factor
+        StakingPositionsMeta.update(session, block, indx.balance_factor)
 
-            # Reset factor
-            indx.balance_factor = Decimal(1)
+        # Reset factor
+        indx.balance_factor = Decimal(1)
 
     class Transfer:
         def new(self, session, indx, block, args):

--- a/models/indexer_state.py
+++ b/models/indexer_state.py
@@ -12,6 +12,6 @@ class IndexerState(Base):
     id = Column(Integer, primary_key=True, default=1)
     last_block = Column(Integer, nullable=False, default=0)
     last_time = Column(TIMESTAMP, nullable=False, default=datetime(1970, 1, 1, 1))
-    balance_factor = Column(NUMERIC(78, 70), nullable=False, default=1.0)
+    balance_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0)
     apy = Column(Float, nullable=False, default=0.0)
     apy_50ms_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0)  # TODO: Remove unused column

--- a/models/indexer_state.py
+++ b/models/indexer_state.py
@@ -12,6 +12,6 @@ class IndexerState(Base):
     id = Column(Integer, primary_key=True, default=1)
     last_block = Column(Integer, nullable=False, default=0)
     last_time = Column(TIMESTAMP, nullable=False, default=datetime(1970, 1, 1, 1))
-    balance_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0)
+    balance_factor = Column(NUMERIC(78, 70), nullable=False, default=1.0)
     apy = Column(Float, nullable=False, default=0.0)
     apy_50ms_factor = Column(NUMERIC(78, 70), nullable=False, default=0.0)  # TODO: Remove unused column


### PR DESCRIPTION
- Skip computing APY if there are no staking positions available
- Refactored the code to only compute APY in a single place (in the `reset_apy_calc` function) and reuse the same function when updating staking positions (in the Transfer event processing function):

https://github.com/sherlock-protocol/sherlock-v2-indexer/blob/1b23d414a11c39a9c872bc1699da5271bf4dd48d/indexer.py#L144-L159
- Removed computing balance factor every block, since we already compensate for the difference in the frontend, so there is no need for having it calculated everytime
- Set the default balance factor to **1**
- Removed the `if balance factor different than 1` check before updating the staking meta, to always update the staking meta, even if it is equal to 1. This way, there are no additional cases that need to be treated, and the staking meta always updates, as long as there is a staking position available to be used in computing the APY. Also, there should be no performance impact, but if one would want to avoid the *useless* db update, we can check for `factor != 1` in the `StakingPositionMeta.update` method, but I don't think it is necessary.