### PR TITLE
Comment event handler order + protocol re-enabling

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -57,9 +57,9 @@ class Indexer:
             settings.CORE_WSS.events.ArbRestaked: self.Restaked.new,
             settings.SHER_BUY_WSS.events.Purchase: self.Purchase.new,
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolAdded: self.ProtocolAdded.new,
-            settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolPremiumChanged: self.ProtocolPremiumChanged.new,
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolAgentTransfer: self.ProtocolAgentTransfer.new,
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolUpdated: self.ProtocolUpdated.new,
+            settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolPremiumChanged: self.ProtocolPremiumChanged.new,
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolRemoved: self.ProtocolRemoved.new,
             settings.SHERLOCK_PROTOCOL_MANAGER_WSS.events.ProtocolRemovedByArb: self.ProtocolRemoved.new,
         }

--- a/indexer.py
+++ b/indexer.py
@@ -266,10 +266,7 @@ class Indexer:
         def new(self, session, indx, block, args):
             protocol_bytes_id = Protocol.parse_bytes_id(args["protocol"])
 
-            protocol = Protocol.get(session, protocol_bytes_id)
-            if not protocol:
-                print("Adding protocol")
-                Protocol.insert(session, protocol_bytes_id)
+            Protocol.insert(session, protocol_bytes_id)
 
     class ProtocolAgentTransfer:
         def new(self, session, indx, block, args):

--- a/indexer.py
+++ b/indexer.py
@@ -50,6 +50,9 @@ class Indexer:
         Currently, this case does not pose an issue, but in the case we will ever delete the protocol
         from the database, on ProtocolRemoved event, we must make sure that event is indexed last,
         so the other event handlers will still have access to the corresponding protocol instance.
+
+        Note: As all contract events are processed in a single database transaction per block,
+        it doesn't cause any unexpected data mutations during the processing.
         """
         self.events = {
             settings.CORE_WSS.events.Transfer: self.Transfer.new,


### PR DESCRIPTION
- Commented the importance of event handler ordering
- Kept the original order because the `ProtocolAdded` event is being handled first, and at no moment in time, the protocol instance is removed from the database so all other events can act on the existing DB instance without issues
- Allowed re-enabling and old inactive protocol. Since we were not removing the DB row on protocol removal, we must only mark it as active (a.k.a set `coverage_ended_at` to NULL) and let the other events take care of the rest.