### PR TITLE
Add status API

### DIFF
--- a/views/__init__.py
+++ b/views/__init__.py
@@ -3,3 +3,4 @@ from .fundraise import *  # noqa
 from .protocols import *  # noqa
 from .staking import *  # noqa
 from .stats import *  # noqa
+from .status import *  # noqa

--- a/views/status.py
+++ b/views/status.py
@@ -1,5 +1,5 @@
 from flask_app import app
-from models import IndexerState, Session, StakingPositionsMeta
+from models import IndexerState, Session, StakingPositions, StakingPositionsMeta
 
 
 @app.route("/status")
@@ -7,6 +7,7 @@ def status():
     with Session() as s:
         indexer_state = s.query(IndexerState).first()
         staking_positions_meta = s.query(StakingPositionsMeta).first()
+        all_positions = s.query(StakingPositions).all()
 
     return {
         "ok": True,
@@ -17,5 +18,6 @@ def status():
             "balance_factor": indexer_state.balance_factor,
             "usdc_last_updated": int(staking_positions_meta.usdc_last_updated.timestamp()),
             "usdc_last_updated_block": staking_positions_meta.usdc_last_updated_block,
+            "staking_positions": [x.to_dict() for x in all_positions],
         },
     }

--- a/views/status.py
+++ b/views/status.py
@@ -1,0 +1,21 @@
+from flask_app import app
+from models import IndexerState, Session, StakingPositionsMeta
+
+
+@app.route("/status")
+def status():
+    with Session() as s:
+        indexer_state = s.query(IndexerState).first()
+        staking_positions_meta = s.query(StakingPositionsMeta).first()
+
+    return {
+        "ok": True,
+        "data": {
+            "last_block": indexer_state.last_block,
+            "last_time": int(indexer_state.last_time.timestamp()),
+            "apy": indexer_state.apy,
+            "balance_factor": indexer_state.balance_factor,
+            "usdc_last_updated": int(staking_positions_meta.usdc_last_updated.timestamp()),
+            "usdc_last_updated_block": staking_positions_meta.usdc_last_updated_block,
+        },
+    }


### PR DESCRIPTION
I have created a `/status` API endpoint that exposes data points related to the indexer's current state.

It will be used by the health monitoring tool to ensure the indexer is running and up to date.